### PR TITLE
dev.capture() not dev.cap()

### DIFF
--- a/R/native.R
+++ b/R/native.R
@@ -5,7 +5,7 @@
 #' red, green, blue, and alpha, so that each get 8 bit, equivalent to 256 
 #' values. It is very seldom that an R user is subjected to this representation,
 #' but it is present in the `nativeRaster` format which can be obtained from 
-#' e.g. capturing the content of a graphic device (using `dev.cap()`) or reading
+#' e.g. capturing the content of a graphic device (using `dev.capture()`) or reading
 #' in PNG files using `png::readPNG(native = TRUE)`. It is very rare that you 
 #' might need to convert back and forth between this format, but it is provided
 #' here for completeness.


### PR DESCRIPTION
minor function name typo